### PR TITLE
Adding ghq Cloning Workflow

### DIFF
--- a/home/erik.jenks/cli/git.nix
+++ b/home/erik.jenks/cli/git.nix
@@ -13,6 +13,19 @@
       ".devenv.*"
       ".envrc"
     ];
+    extraConfig = {
+      ghq = {
+        root = "~/src";
+      };
+    };
+  };
+
+  home.packages = with pkgs; [
+    ghq
+  ];
+
+  home.shellAliases = {
+    gcd = "dst=$(ghq list | fzf --height=~10) && cd $(ghq root)/$dst";
   };
 
 }


### PR DESCRIPTION
Installs [ghq](https://github.com/x-motemen/ghq), a CLI for managing your cloned repositories in a `~/src/github.com/get-bridge/get_smart` style.

- Clone Hubble: `ghq get -p get-bridge/hubble`
- List all: `ghq list`
- Fuzzy cd: `gcd`